### PR TITLE
Fix intermittent test failure in  TestEthereumMultipartyE2ESuite

### DIFF
--- a/internal/namespace/manager.go
+++ b/internal/namespace/manager.go
@@ -191,7 +191,12 @@ func (nm *namespaceManager) Init(ctx context.Context, cancelCtx context.CancelFu
 	nm.reset = reset               // channel to ask our parent to reload us
 	nm.reloadConfig = reloadConfig // function to cause our parent to call InitConfig on all components, including us
 	nm.ctx = ctx
-	nm.cancelCtx = cancelCtx
+	nm.cancelCtx = func() {
+		// only propagate a process-stop request while our own context is still active
+		if ctx.Err() == nil {
+			cancelCtx()
+		}
+	}
 
 	initTimeRawConfig := nm.dumpRootConfig()
 	nm.loadManagers(ctx)
@@ -424,12 +429,15 @@ func (nm *namespaceManager) WaitStop() {
 	for k, v := range nm.namespaces {
 		namespaces[k] = v
 	}
+	adminEvents := nm.adminEvents // copy in mux
 	nm.nsMux.Unlock()
 
 	for _, ns := range namespaces {
 		nm.stopNamespace(nm.ctx, ns)
 	}
-	nm.adminEvents.WaitStop()
+	if adminEvents != nil {
+		adminEvents.WaitStop()
+	}
 }
 
 func (nm *namespaceManager) Reset(ctx context.Context) error {

--- a/internal/namespace/manager_test.go
+++ b/internal/namespace/manager_test.go
@@ -1930,6 +1930,33 @@ func TestWaitStop(t *testing.T) {
 	nmm.mae.AssertExpectations(t)
 }
 
+func TestWaitStopBeforeInit(t *testing.T) {
+	nm := &namespaceManager{}
+	nm.WaitStop()
+}
+
+func TestCancelCtxSuppressedWhenStopping(t *testing.T) {
+	nm, nmm, cleanup := newTestNamespaceManager(t, false)
+	defer cleanup()
+
+	nmm.mei[0].On("Init", mock.Anything, mock.Anything).Return(nil)
+	nmm.mei[1].On("Init", mock.Anything, mock.Anything).Return(nil)
+	nmm.mei[2].On("Init", mock.Anything, mock.Anything).Return(nil)
+
+	ctx, cancelRunCtx := context.WithCancel(context.Background())
+	rootCancelled := false
+	err := nm.Init(ctx, func() { rootCancelled = true }, nm.reset, nm.reloadConfig)
+	assert.NoError(t, err)
+
+	nm.cancelCtx() // propagate a request to stop while we're running
+	assert.True(t, rootCancelled)
+
+	rootCancelled = false
+	cancelRunCtx()
+	nm.cancelCtx() // if we're already stopping, it's a no-op
+	assert.False(t, rootCancelled)
+}
+
 func TestReset(t *testing.T) {
 	nm, _, cleanup := newTestNamespaceManager(t, true)
 	defer cleanup()


### PR DESCRIPTION
## Proposed changes

Fix intermittent test failure seen in https://github.com/hyperledger-firefly/firefly/actions/runs/33285848182/job/99189056912?pr=1776

```
firefly_e2e_firefly_core_0  | [2026-08-30T01:39:12.773Z]  INFO Shutting down due to cancelled context pid=1
firefly_e2e_firefly_core_0  | panic: runtime error: invalid memory address or nil pointer dereference
firefly_e2e_firefly_core_0  | [signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0xe61a16]
firefly_e2e_firefly_core_0  | 
firefly_e2e_firefly_core_0  | goroutine 1 [running]:
firefly_e2e_firefly_core_0  | github.com/hyperledger-firefly/firefly/internal/namespace.(*namespaceManager).WaitStop(0x224e4a27ab60)
firefly_e2e_firefly_core_0  | 	/firefly/internal/namespace/manager.go:432 +0x236
firefly_e2e_firefly_core_0  | github.com/hyperledger-firefly/firefly/cmd.run()
firefly_e2e_firefly_core_0  | 	/firefly/cmd/firefly.go:165 +0x7d5
firefly_e2e_firefly_core_0  | github.com/hyperledger-firefly/firefly/cmd.init.func2(0x224e4987cf00?, {0x125c57b?, 0x4?, 0x125c38b?})
firefly_e2e_firefly_core_0  | 	/firefly/cmd/firefly.go:53 +0xf
firefly_e2e_firefly_core_0  | github.com/spf13/cobra.(*Command).execute(0x1c805c0, {0x224e4939a080, 0x0, 0x0})
firefly_e2e_firefly_core_0  | 	/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:983 +0xb34
firefly_e2e_firefly_core_0  | github.com/spf13/cobra.(*Command).ExecuteC(0x1c805c0)
firefly_e2e_firefly_core_0  | 	/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x44f
firefly_e2e_firefly_core_0  | github.com/spf13/cobra.(*Command).Execute(...)
firefly_e2e_firefly_core_0  | 	/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
firefly_e2e_firefly_core_0  | github.com/hyperledger-firefly/firefly/cmd.Execute(...)
firefly_e2e_firefly_core_0  | 	/firefly/cmd/firefly.go:104
firefly_e2e_firefly_core_0  | main.main()
firefly_e2e_firefly_core_0  | 	/firefly/main.go:27 +0x1a
```

- [x] Bug fix 
- [ ] New feature added
- [ ] Documentation Update 

<hr>

## Please make sure to follow these points 

- [x] I have read the contributing guidelines.
- [x] I have performed a self-review of my own code or work.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generates no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My changes have sufficient code coverage (unit, integration, e2e tests).

